### PR TITLE
hide overflow-x to prevent sidescrolling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,6 +10,7 @@
 body {
   margin: 0;
   padding: 0;
+  overflow-x: hidden;
   background: rgb(52, 50, 57);
   background: linear-gradient(
     45deg,


### PR DESCRIPTION
Added a line to body in the main css file to prevent side scrolling. It was possible because the width of the Timeline exceeds the window width.